### PR TITLE
hub/commands: recover_funds - explicit cast to avoid warning 

### DIFF
--- a/hub/commands/recover_funds.cc
+++ b/hub/commands/recover_funds.cc
@@ -155,7 +155,7 @@ common::cmd::Error RecoverFunds::doProcess(
     std::vector<hub::db::TransferInput> deposits;
 
     hub::db::TransferInput ti = {
-      addressId : maybeAddressInfo.value().id,
+      addressId : static_cast<int64_t>(maybeAddressInfo.value().id),
       userId : userId,
       address : address.value(),
       uuid : maybeAddressInfo.value().uuid,


### PR DESCRIPTION
# Description

static cast uint to int to avoid warning which is error on MacOS

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


# Checklist:

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
