### PR TITLE
hub/commands: add cmd to get seed from uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ See [Getting Started](docs/getting_started.md) for information on how to use the
     -RecoverFunds_enabled (Whether the RecoverFunds API call should be available) 
       type: bool (--RecoverFunds_enabled or --noRecoverFunds_enabled)
       
+    -GetSeedForAddress_enabled (Whether the GetAddressForAddress API call should be available) 
+    type: bool (--GetSeedForAddress_enabled or --noGetSeedForAddress_enabled)
+      
 ```
 
 ## Useful things

--- a/common/crypto/argon2_provider.cc
+++ b/common/crypto/argon2_provider.cc
@@ -43,8 +43,8 @@ using TryteSeed = std::array<tryte_t, TRYTE_LEN + 1>;
 using TryteSeedPtr =
     std::unique_ptr<TryteSeed, std::function<void(TryteSeed*)>>;
 
-TryteSeedPtr seedFromUUID(const common::crypto::UUID& uuid,
-                          const std::string& _salt) {
+TryteSeedPtr seedFromUUIDInternal(const common::crypto::UUID& uuid,
+                                  const std::string& _salt) {
   static boost::interprocess::interprocess_semaphore argon_semaphore(
       common::flags::FLAGS_maxConcurrentArgon2Hash);
 
@@ -104,11 +104,17 @@ Argon2Provider::Argon2Provider(std::string salt) : _salt(std::move(salt)) {
   }
 }
 
+std::string Argon2Provider::getSeedFromUUID(
+    const common::crypto::UUID& uuid) const {
+  auto seedPtr = seedFromUUIDInternal(uuid, _salt);
+  return std::string((char*)seedPtr->data());
+}
+
 nonstd::optional<common::crypto::Address> Argon2Provider::getAddressForUUID(
     const common::crypto::UUID& uuid) const {
   LOG(INFO) << "Generating address for: " << uuid.str().substr(0, 16);
 
-  auto seed = seedFromUUID(uuid, _salt);
+  auto seed = seedFromUUIDInternal(uuid, _salt);
   if (!securityLevel(uuid).has_value()) {
     LOG(INFO) << "Failed in getting the security level.";
     return {};
@@ -131,7 +137,7 @@ nonstd::optional<std::string> Argon2Provider::doGetSignatureForUUID(
   LOG(INFO) << "Generating signature for: " << uuid.str().substr(0, 16)
             << ", bundle: " << bundleHash.str_view();
 
-  auto seed = seedFromUUID(uuid, _salt);
+  auto seed = seedFromUUIDInternal(uuid, _salt);
 
   IOTA::Models::Bundle bundle;
   auto normalized = bundle.normalizedBundle(bundleHash.str());

--- a/common/crypto/argon2_provider.h
+++ b/common/crypto/argon2_provider.h
@@ -36,6 +36,13 @@ class Argon2Provider : public CryptoProviderBase {
   nonstd::optional<size_t> securityLevel(
       const common::crypto::UUID& uuid) const override;
 
+  /// Calculate the seed for a UUID.
+  /// param[in] UUID - a UUID
+  /// @return string - the seed
+
+  virtual std::string getSeedFromUUID(
+      const common::crypto::UUID& uuid) const override;
+
  protected:
   /// Calculate the signature for a UUID and a bundle hash
   /// param[in] UUID - a UUID

--- a/common/crypto/provider_base.h
+++ b/common/crypto/provider_base.h
@@ -61,6 +61,13 @@ class CryptoProviderBase {
     return doGetSignatureForUUID(uuid, bundleHash);
   }
 
+  /// Calculate the seed for a UUID.
+  /// param[in] UUID - a UUID
+  /// @return string - the seed
+
+  virtual std::string getSeedFromUUID(
+      const common::crypto::UUID& uuid) const = 0;
+
  protected:
   /// Calculate the signature for a UUID and a bundle hash
   /// param[in] UUID - a UUID

--- a/docs/http_rest_api.md
+++ b/docs/http_rest_api.md
@@ -540,6 +540,42 @@
         ...
     }
     ```
+    
+    
+### GetSeedForAddress
+
+- Return the seed that is associated with an address,
+  There's no need for Hub operators to know seeds
+  since signature is derived internally using the address's uuid,
+  but some would like to store the seed in case where db is crashed
+  before it was backuped, then user can use the seed to generate a signature 
+  and recover any locked funds if somehow the db record is lost 
+
+- Arguments
+
+
+|Arg name            |type                 |Description                                                    |
+|--------------------|---------------------|---------------------------------------------------------------|
+| userId             |string               | The user's identifier
+| address            |string (81 trytes)   | The address
+
+
+- curl example:
+    - Call:
+        
+    ``` 
+    curl  http://localhost:50051  -X POST   -H 'Content-Type: application/json'   -H 'X-IOTA-API-Version:  1'   -d '{"command": "GetSeedForAddress", "userId": "SomeUser"  , "address" : "LFABJNKAKJVXYH9OPVZ9HJFOPOHDAGKOHZSRWHSNXYBHCYWQDHGRVKPFBLSGRZUOBL9DUBCKI9DWSPEJA"}'  
+    ```
+    
+    - Output:
+
+    ```
+    {
+        "seed": "AUVEOUEVFHKZBKCSVWDQ9PJPDJZPZ9APNBLYCFLFLEBHMJUJYXEBSZFGTFDASHHGEKOHHEHIMUXKZWUTD"
+    }
+
+       
+    ```
 
 
     

--- a/hub/commands/get_seed_for_address.cc
+++ b/hub/commands/get_seed_for_address.cc
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/hub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include <cstdint>
+
+#include "common/converter.h"
+#include "common/crypto/manager.h"
+#include "common/crypto/types.h"
+#include "hub/commands/factory.h"
+#include "hub/commands/helper.h"
+#include "hub/db/helper.h"
+
+#include "hub/commands/get_seed_for_address.h"
+
+namespace hub {
+namespace cmd {
+
+static CommandFactoryRegistrator<GetSeedForAddress> registrator;
+
+boost::property_tree::ptree GetSeedForAddress::doProcess(
+    const boost::property_tree::ptree& request) noexcept {
+  boost::property_tree::ptree tree;
+
+  GetSeedForAddressRequest req;
+  GetSeedForAddressReply rep;
+  auto maybeUserId = request.get_optional<std::string>("userId");
+  if (!maybeUserId) {
+    tree.add("error",
+             common::cmd::getErrorString(common::cmd::MISSING_ARGUMENT));
+    return tree;
+  }
+
+  req.userId = maybeUserId.value();
+
+  auto maybeAddress = request.get_optional<std::string>("address");
+  if (!maybeAddress) {
+    tree.add("error",
+             common::cmd::getErrorString(common::cmd::MISSING_ARGUMENT));
+    return tree;
+  }
+
+  req.address = maybeAddress.value();
+
+  auto status = doProcess(&req, &rep);
+
+  if (status != common::cmd::OK) {
+    tree.add("error", common::cmd::getErrorString(status));
+  } else {
+    tree.add("seed", rep.seed);
+  }
+  return tree;
+}
+
+common::cmd::Error GetSeedForAddress::doProcess(
+    const GetSeedForAddressRequest* request,
+    GetSeedForAddressReply* response) noexcept {
+  uint64_t userId;
+
+  auto& connection = db::DBManager::get().connection();
+
+  // Get userId for identifier
+  {
+    auto maybeUserId = connection.userIdFromIdentifier(request->userId);
+    if (!maybeUserId) {
+      return common::cmd::USER_DOES_NOT_EXIST;
+    }
+
+    userId = maybeUserId.value();
+  }
+
+  common::crypto::UUID uuid;
+  auto maybeAddress =
+      common::crypto::CryptoManager::get().provider().getAddressForUUID(uuid);
+  if (!maybeAddress.has_value()) {
+    LOG(ERROR) << session() << " Failed in getAddressForUUID from provider.";
+    return common::cmd::GET_ADDRESS_FAILED;
+  }
+
+  nonstd::optional<common::crypto::Address> maybeTrinaryAddress =
+      nonstd::nullopt;
+
+  try {
+    maybeTrinaryAddress = {common::crypto::Address(request->address)};
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << session() << "Invalid address: " << ex.what();
+    return common::cmd::INVALID_ADDRESS;
+  }
+
+  auto maybeAddressInfo =
+      connection.getAddressInfo(maybeTrinaryAddress.value());
+  if (!maybeAddressInfo) {
+    return common::cmd::UNKNOWN_ADDRESS;
+  }
+
+  if (maybeAddressInfo->userId.compare(request->userId) != 0) {
+    return common::cmd::WRONG_USER_ADDRESS;
+  }
+
+  response->seed =
+      common::crypto::CryptoManager::get().provider().getSeedFromUUID(
+          maybeAddressInfo.value().uuid);
+
+  return common::cmd::OK;
+}
+}  // namespace cmd
+}  // namespace hub

--- a/hub/commands/get_seed_for_address.cc
+++ b/hub/commands/get_seed_for_address.cc
@@ -72,14 +72,6 @@ common::cmd::Error GetSeedForAddress::doProcess(
     userId = maybeUserId.value();
   }
 
-  common::crypto::UUID uuid;
-  auto maybeAddress =
-      common::crypto::CryptoManager::get().provider().getAddressForUUID(uuid);
-  if (!maybeAddress.has_value()) {
-    LOG(ERROR) << session() << " Failed in getAddressForUUID from provider.";
-    return common::cmd::GET_ADDRESS_FAILED;
-  }
-
   nonstd::optional<common::crypto::Address> maybeTrinaryAddress =
       nonstd::nullopt;
 

--- a/hub/commands/get_seed_for_address.h
+++ b/hub/commands/get_seed_for_address.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/hub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef HUB_COMMANDS_GET_SEED_FOR_ADDRESS_H_
+#define HUB_COMMANDS_GET_SEED_FOR_ADDRESS_H_
+
+#include <string>
+
+#include "common/commands/command.h"
+
+namespace hub {
+namespace cmd {
+
+typedef struct GetSeedForAddressRequest {
+  std::string userId;
+  std::string address;
+} GetSeedForAddressRequest;
+
+typedef struct GetSeedForAddressReply {
+  std::string seed;
+} GetSeedForAddressReply;
+
+class GetSeedForAddress
+    : public common::Command<GetSeedForAddressRequest, GetSeedForAddressReply> {
+ public:
+  using Command<GetSeedForAddressRequest, GetSeedForAddressReply>::Command;
+
+  static std::shared_ptr<common::ICommand> create() {
+    return std::shared_ptr<common::ICommand>(
+        new GetSeedForAddress(std::make_shared<common::ClientSession>()));
+  }
+
+  static const std::string name() { return "GetSeedForAddress"; }
+
+  common::cmd::Error doProcess(
+      const GetSeedForAddressRequest* request,
+      GetSeedForAddressReply* response) noexcept override;
+
+  boost::property_tree::ptree doProcess(
+      const boost::property_tree::ptree& request) noexcept override;
+};
+}  // namespace cmd
+}  // namespace hub
+
+#endif  // HUB_COMMANDS_GET_SEED_FOR_ADDRESS_H_

--- a/hub/commands/recover_funds.cc
+++ b/hub/commands/recover_funds.cc
@@ -30,15 +30,14 @@ static CommandFactoryRegistrator<RecoverFunds> registrator;
 boost::property_tree::ptree RecoverFunds::doProcess(
     const boost::property_tree::ptree& request) noexcept {
   boost::property_tree::ptree tree;
+  RecoverFundsRequest req;
+  RecoverFundsReply rep;
 
   if (!FLAGS_RecoverFunds_enabled) {
     LOG(ERROR) << session() << ": Recover funds is disabled";
     tree.add("error", common::cmd::getErrorString(common::cmd::CANCELLED));
     return tree;
   }
-
-  RecoverFundsRequest req;
-  RecoverFundsReply rep;
 
   auto maybeUserId = request.get_optional<std::string>("userId");
   if (!maybeUserId) {

--- a/hub/crypto/remote_signing_provider.cc
+++ b/hub/crypto/remote_signing_provider.cc
@@ -97,5 +97,20 @@ nonstd::optional<std::string> RemoteSigningProvider::doGetSignatureForUUID(
   return {response.signature()};
 }
 
+std::string RemoteSigningProvider::getSeedFromUUID(
+    const common::crypto::UUID& uuid) const {
+  ClientContext context;
+  signing::rpc::GetSeedForUUIDRequest request;
+  request.set_uuid(uuid.str());
+  signing::rpc::GetSeedForUUIDReply response;
+
+  Status status = _stub->GetSeedForUUID(&context, request, &response);
+  if (!status.ok()) {
+    LOG(ERROR) << "GetSeedForUUID rpc failed:" << status.error_message();
+    return {};
+  }
+  return {response.seed()};
+}
+
 }  // namespace crypto
 }  // namespace hub

--- a/hub/crypto/remote_signing_provider.h
+++ b/hub/crypto/remote_signing_provider.h
@@ -49,6 +49,13 @@ class RemoteSigningProvider : public common::crypto::CryptoProviderBase {
     return doGetSignatureForUUID(uuid, bundleHash);
   }
 
+  /// Calculate the seed for a UUID.
+  /// param[in] UUID - a UUID
+  /// @return string - the seed
+
+  virtual std::string getSeedFromUUID(
+      const common::crypto::UUID& uuid) const override;
+
  protected:
   /// Calculate the signature for a UUID and a bundle hash
   /// param[in] UUID - a UUID

--- a/hub/server/grpc.cc
+++ b/hub/server/grpc.cc
@@ -22,6 +22,7 @@
 #include "hub/commands/get_address_info.h"
 #include "hub/commands/get_balance.h"
 #include "hub/commands/get_deposit_address.h"
+#include "hub/commands/get_seed_for_address.h"
 #include "hub/commands/get_stats.h"
 #include "hub/commands/get_user_history.h"
 #include "hub/commands/process_transfer_batch.h"
@@ -409,6 +410,23 @@ grpc::Status HubImpl::RecoverFunds(
   request.validateChecksum = rpcRequest->validatechecksum();
   request.address = rpcRequest->address();
   return common::cmd::errorToGrpcError(cmd.process(&request, &response));
+}
+
+grpc::Status HubImpl::GetSeedForAddress(
+    grpc::ServerContext* context,
+    const hub::rpc::GetSeedForAddressRequest* rpcRequest,
+    hub::rpc::GetSeedForAddressReply* rpcResponse) {
+  auto clientSession = std::make_shared<common::ClientSession>();
+  cmd::GetSeedForAddress cmd(clientSession);
+  cmd::GetSeedForAddressRequest request;
+  cmd::GetSeedForAddressReply response;
+  request.userId = rpcRequest->userid();
+  request.address = rpcRequest->address();
+  auto status = common::cmd::errorToGrpcError(cmd.process(&request, &response));
+  if (status.ok()) {
+    rpcResponse->set_seed(response.seed);
+  }
+  return status;
 }
 
 }  // namespace hub

--- a/hub/server/grpc.h
+++ b/hub/server/grpc.h
@@ -171,7 +171,7 @@ class HubImpl final : public hub::rpc::Hub::Service {
                             const hub::rpc::RecoverFundsRequest* request,
                             hub::rpc::RecoverFundsReply* response) override;
 
-  /// Gets seed from given address
+  /// Gets the seed for a given address
   /// @param[in] context - server context
   /// @param[in] request - a rpc::RecoverFundsRequest request
   /// @param[in] response - a rpc::RecoverFundsReply response

--- a/hub/server/grpc.h
+++ b/hub/server/grpc.h
@@ -171,6 +171,17 @@ class HubImpl final : public hub::rpc::Hub::Service {
                             const hub::rpc::RecoverFundsRequest* request,
                             hub::rpc::RecoverFundsReply* response) override;
 
+  /// Gets seed from given address
+  /// @param[in] context - server context
+  /// @param[in] request - a rpc::RecoverFundsRequest request
+  /// @param[in] response - a rpc::RecoverFundsReply response
+  /// @return grpc::Status
+
+  grpc::Status GetSeedForAddress(
+      grpc::ServerContext* context,
+      const hub::rpc::GetSeedForAddressRequest* request,
+      hub::rpc::GetSeedForAddressReply* response) override;
+
  private:
   std::shared_ptr<cppclient::IotaAPI> _api;
 };

--- a/proto/hub.proto
+++ b/proto/hub.proto
@@ -46,5 +46,7 @@ service Hub {
   //instead, the "RecoverFunds" creates a bundle that spend the entire balance that
   //is found on the given address
   rpc RecoverFunds (RecoverFundsRequest) returns (RecoverFundsReply);
+  //Get the seed associated with the given address - this function can be used for backing up the seed
+  rpc GetSeedForAddress (GetSeedForAddressRequest) returns (GetSeedForAddressReply);
 }
 

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -359,3 +359,16 @@ message RecoverFundsRequest {
 
 message RecoverFundsReply {}
 
+message GetSeedForAddressRequest{
+    //The user id
+    string userId = 1;
+    //The address in question
+    string address = 2;
+}
+
+message GetSeedForAddressReply{
+    //The seed
+    string seed = 1;
+}
+
+

--- a/proto/signing_server.proto
+++ b/proto/signing_server.proto
@@ -12,4 +12,6 @@ service SigningServer {
     rpc GetSignatureForUUID (GetSignatureForUUIDRequest) returns (GetSignatureForUUIDReply);
     // Gets the security level of the provider
     rpc GetSecurityLevel (GetSecurityLevelRequest) returns (GetSecurityLevelReply);
+    //Get the seed associated with the given address - this function can be used for backing up the seed
+    rpc GetSeedForUUID (GetSeedForUUIDRequest) returns (GetSeedForUUIDReply);
 }

--- a/proto/signing_server_messages.proto
+++ b/proto/signing_server_messages.proto
@@ -63,3 +63,15 @@ message GetSecurityLevelRequest {
 message GetSecurityLevelReply {
     uint32 securityLevel = 1;
 }
+
+
+message GetSeedForUUIDRequest{
+    //The uuid
+    string uuid = 1;
+}
+
+message GetSeedForUUIDReply{
+    //The seed
+    string seed = 1;
+}
+

--- a/signing_server/commands/get_address_for_uuid.cc
+++ b/signing_server/commands/get_address_for_uuid.cc
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/hub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+
 #include "get_address_for_uuid.h"
 
 #include "common/crypto/manager.h"

--- a/signing_server/commands/get_security_level.cc
+++ b/signing_server/commands/get_security_level.cc
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/hub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
 #include "get_security_level.h"
 
 #include "common/crypto/manager.h"

--- a/signing_server/commands/get_seed_for_uuid.cc
+++ b/signing_server/commands/get_seed_for_uuid.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/hub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#include "get_seed_for_uuid.h"
+
+#include "common/crypto/manager.h"
+#include "proto/signing_server.pb.h"
+#include "proto/signing_server_messages.pb.h"
+
+#include "common/crypto/types.h"
+#include "proto/messages.pb.h"
+#include "signing_server/commands/helper.h"
+
+namespace signing {
+    namespace cmd {
+
+        common::cmd::Error GetSeedForUUID::doProcess(
+                const signing::rpc::GetSeedForUUIDRequest* request,
+                signing::rpc::GetSeedForUUIDReply* response) noexcept {
+            try {
+                LOG(INFO) << session() << " GetSeedForUUID: " << request->uuid();
+
+                common::crypto::UUID uuid(request->uuid());
+                auto seed = common::crypto::CryptoManager::get()
+                        .provider()
+                        .getSeedFromUUID(uuid)
+                        .value();
+                response->set_seed(seed.str());
+            } catch (const std::runtime_error& ex) {
+                LOG(ERROR) << session() << "Failed: " << ex.what();
+
+                return common::cmd::UNKNOWN_ERROR;
+            }
+
+            return common::cmd::OK;
+        }
+
+    }  // namespace cmd
+
+}  // namespace signing

--- a/signing_server/commands/get_seed_for_uuid.cc
+++ b/signing_server/commands/get_seed_for_uuid.cc
@@ -27,9 +27,9 @@ namespace signing {
                 common::crypto::UUID uuid(request->uuid());
                 auto seed = common::crypto::CryptoManager::get()
                         .provider()
-                        .getSeedFromUUID(uuid)
-                        .value();
-                response->set_seed(seed.str());
+                        .getSeedFromUUID(uuid);
+
+                response->set_seed(seed);
             } catch (const std::runtime_error& ex) {
                 LOG(ERROR) << session() << "Failed: " << ex.what();
 

--- a/signing_server/commands/get_seed_for_uuid.h
+++ b/signing_server/commands/get_seed_for_uuid.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/hub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
+#ifndef SIGNING_SERVER_COMMANDS_GET_SEED_FOR_UUID_H_
+#define SIGNING_SERVER_COMMANDS_GET_SEED_FOR_UUID_H_
+
+#include <string>
+
+#include "common/commands/command.h"
+
+namespace signing {
+    namespace rpc {
+        class GetSeedForUUIDRequest;
+        class GetSeedForUUIDReply;
+    }  // namespace rpc
+
+    namespace cmd {
+
+/// Gets information on an uuid
+/// @param[in] common::rpc::GetSeedForUUIDRequest
+/// @param[in] common::rpc::GetSeedForUUIDReply
+        class GetSeedForUUID
+                : public common::Command<signing::rpc::GetSeedForUUIDRequest,
+                        signing::rpc::GetSeedForUUIDReply> {
+        public:
+            using common::Command<signing::rpc::GetSeedForUUIDRequest,
+                    signing::rpc::GetSeedForUUIDReply>::Command;
+
+            static const std::string name() { return "GetSeedForUUID"; }
+
+            common::cmd::Error doProcess(
+                    const signing::rpc::GetSeedForUUIDRequest* request,
+                    signing::rpc::GetSeedForUUIDReply* response) noexcept override;
+
+            boost::property_tree::ptree doProcess(
+                    const boost::property_tree::ptree& request) noexcept override {return boost::property_tree::ptree();};
+        };
+    }  // namespace cmd
+}  // namespace signing
+
+#endif  // SIGNING_SERVER_COMMANDS_GET_SEED_FOR_UUID_H_

--- a/signing_server/commands/get_signature_for_uuid.cc
+++ b/signing_server/commands/get_signature_for_uuid.cc
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2019 IOTA Stiftung
+ * https://github.com/iotaledger/hub
+ *
+ * Refer to the LICENSE file for licensing information
+ */
+
 #include "get_signature_for_uuid.h"
 
 #include "common/crypto/manager.h"

--- a/signing_server/grpc.cc
+++ b/signing_server/grpc.cc
@@ -10,7 +10,6 @@
 #include "common/stats/session.h"
 #include "signing_server/commands/get_address_for_uuid.h"
 #include "signing_server/commands/get_security_level.h"
-#include "signing_server/commands/get_signature_for_uuid.h"
 
 #include <memory>
 #include <string>
@@ -41,6 +40,15 @@ grpc::Status SigningServerImpl::GetSecurityLevel(
   auto clientSession = std::make_shared<common::ClientSession>();
   cmd::GetSecurityLevel cmd(clientSession);
   return common::cmd::errorToGrpcError(cmd.process(request, response));
+}
+
+    grpc::Status SigningServerImpl::GetSeedForUuid(
+            grpc::ServerContext* context,
+            const GetSeedForAddressRequest* request,
+            GetSeedForAddressReply* response){
+        auto clientSession = std::make_shared<common::ClientSession>();
+        cmd::GetSeedForAddress cmd(clientSession);
+        return common::cmd::errorToGrpcError(cmd.process(request, response));
 }
 
 }  // namespace rpc

--- a/signing_server/grpc.cc
+++ b/signing_server/grpc.cc
@@ -5,14 +5,16 @@
  * Refer to the LICENSE file for licensing information
  */
 
+#include <memory>
+#include <string>
+
 #include "signing_server/grpc.h"
 #include "common/crypto/provider_base.h"
 #include "common/stats/session.h"
 #include "signing_server/commands/get_address_for_uuid.h"
 #include "signing_server/commands/get_security_level.h"
-
-#include <memory>
-#include <string>
+#include "signing_server/commands/get_seed_for_uuid.h"
+#include "signing_server/commands/get_signature_for_uuid.h"
 
 namespace signing {
 namespace rpc {
@@ -42,12 +44,12 @@ grpc::Status SigningServerImpl::GetSecurityLevel(
   return common::cmd::errorToGrpcError(cmd.process(request, response));
 }
 
-    grpc::Status SigningServerImpl::GetSeedForUuid(
+    grpc::Status SigningServerImpl::GetSeedForUUID(
             grpc::ServerContext* context,
-            const GetSeedForAddressRequest* request,
-            GetSeedForAddressReply* response){
+            const GetSeedForUUIDRequest* request,
+            GetSeedForUUIDReply* response){
         auto clientSession = std::make_shared<common::ClientSession>();
-        cmd::GetSeedForAddress cmd(clientSession);
+        cmd::GetSeedForUUID cmd(clientSession);
         return common::cmd::errorToGrpcError(cmd.process(request, response));
 }
 

--- a/signing_server/grpc.h
+++ b/signing_server/grpc.h
@@ -38,6 +38,12 @@ class SigningServerImpl final : public SigningServer::Service {
   grpc::Status GetSecurityLevel(::grpc::ServerContext* context,
                                 const GetSecurityLevelRequest* request,
                                 GetSecurityLevelReply* response) override;
+
+    /// Gets seed for a uuid
+    grpc::Status GetSeedForUuid(
+            grpc::ServerContext* context,
+            const GetSeedForUuidRequest* request,
+            GetSeedForUuidReply* response) override;
 };
 
 }  // namespace rpc

--- a/signing_server/grpc.h
+++ b/signing_server/grpc.h
@@ -40,10 +40,10 @@ class SigningServerImpl final : public SigningServer::Service {
                                 GetSecurityLevelReply* response) override;
 
     /// Gets seed for a uuid
-    grpc::Status GetSeedForUuid(
+    grpc::Status GetSeedForUUID(
             grpc::ServerContext* context,
-            const GetSeedForUuidRequest* request,
-            GetSeedForUuidReply* response) override;
+            const GetSeedForUUIDRequest* request,
+            GetSeedForUUIDReply* response) override;
 };
 
 }  // namespace rpc


### PR DESCRIPTION
# Description

Add API for getting seed that is associated with an address,
this might be useful for anyone who wants to be able to backup seeds without being dependent
on some periodical db dump

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix (missing)
# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
