### PR TITLE
Backup unswept hub addresses (and parent seeds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ See [Getting Started](docs/getting_started.md) for information on how to use the
     -sweep_max_withdraw (Maximum number of withdraw requests to service per
       sweep.) type: uint32 default: 7
       
+    -hubAdressesBackupPath (Path to file used for backing up hub unswept hub addresses) type: string default: ""
+      
   Flags from hub/server/grpc.cc:
     -SignBundle_enabled (Whether the SignBundle API call should be available) 
       type: bool (--SignBundle_enabled or --noSignBundle_enabled)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ See [Getting Started](docs/getting_started.md) for information on how to use the
     -sweep_max_withdraw (Maximum number of withdraw requests to service per
       sweep.) type: uint32 default: 7
       
-    -hubAdressesBackupPath (Path to file used for backing up hub unswept hub addresses) type: string default: ""
+    -hubSeedsBackupPath (Path to file used for backing up hub unswept hub addresses and seeds [address;seed;amount]) 
+        type: string default: ""
+    
       
   Flags from hub/server/grpc.cc:
     -SignBundle_enabled (Whether the SignBundle API call should be available) 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,10 +6,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # EXTERNAL RULES
 http_archive(
     name = "com_github_grpc_grpc",
-    sha256 = "d6af0859d3ae4693b1955e972aa2e590d6f4d44baaa82651467c6beea453e30e",
-    strip_prefix = "grpc-1.26.0-pre1",
+    sha256 = "2fcb7f1ab160d6fd3aaade64520be3e5446fc4c6fa7ba6581afdc4e26094bd81",
+    strip_prefix = "grpc-1.26.0",
     urls = [
-        "https://github.com/grpc/grpc/archive/v1.26.0-pre1.tar.gz",
+        "https://github.com/grpc/grpc/archive/v1.26.0.tar.gz",
     ],
 )
 

--- a/hub/db/connection.h
+++ b/hub/db/connection.h
@@ -265,12 +265,19 @@ class Connection {
   virtual std::vector<TransferInput> getDepositsForSweep(
       size_t max, const std::chrono::system_clock::time_point& olderThan) = 0;
 
-  /// Return a list of hub inputs up to a point in time
+  /// Return a list of hub inputs up to a point in time (confirmed)
   /// @param[in] requiredAmount - the required total amount to obtain
   /// @param[in] olderThan - the cutoff point in time
   /// @return std::vector - a list of TransferInput
   virtual std::vector<TransferInput> getHubInputsForSweep(
       uint64_t requiredAmount,
+      const std::chrono::system_clock::time_point& olderThan) = 0;
+
+  /// Return a list of hub inputs up to a point in time
+  /// @param[in] requiredAmount - the required total amount to obtain
+  /// @param[in] olderThan - the cutoff point in time
+  /// @return std::vector - a list of TransferInput
+  virtual std::vector<TransferInput> getAllHubInputs(
       const std::chrono::system_clock::time_point& olderThan) = 0;
 
   /// @param[in] sweepId - the sweepId if the creation results from a sweep

--- a/hub/db/connection_impl.h
+++ b/hub/db/connection_impl.h
@@ -243,6 +243,11 @@ class ConnectionImpl : public Connection {
                                                   olderThan);
   }
 
+  std::vector<TransferInput> getAllHubInputs(
+      const std::chrono::system_clock::time_point& olderThan) override {
+    return db::helper<Conn>::getAllHubInputs(*_conn, olderThan);
+  }
+
   bool isSweepConfirmed(uint64_t sweepId) override {
     return db::helper<Conn>::isSweepConfirmed(*_conn, sweepId);
   }

--- a/hub/db/helper.h
+++ b/hub/db/helper.h
@@ -132,6 +132,9 @@ struct helper {
       C& connection, uint64_t requiredAmount,
       const std::chrono::system_clock::time_point& olderThan);
 
+  static std::vector<TransferInput> getAllHubInputs(
+      C& connection, const std::chrono::system_clock::time_point& olderThan);
+
   static nonstd::optional<AddressInfo> getAddressInfo(
       C& connection, const common::crypto::Address& address);
 

--- a/hub/service/sweep_service.cc
+++ b/hub/service/sweep_service.cc
@@ -74,7 +74,7 @@ void SweepService::backupUnsweptHubAddresses() const {
     auto allHubInputs =
         dbConnection.getAllHubInputs(std::chrono::system_clock::now());
 
-    for (auto&& inp : allHubInputs) {
+    for (const auto& inp : allHubInputs) {
       outputFile << inp.address.str() << ";" << inp.uuid.str() << ";"
                  << inp.amount << "\n";
     }

--- a/hub/service/sweep_service.cc
+++ b/hub/service/sweep_service.cc
@@ -93,19 +93,16 @@ void SweepService::backupUnsweptHubAddresses() const {
   outputFile.close();
 
   if (replace) {
-    std::string pathToDelete = FLAGS_hubSeedsBackupPath + "_to_delete";
-
     try {
-      fs::rename(FLAGS_hubSeedsBackupPath, pathToDelete);
+        fs::remove(FLAGS_hubSeedsBackupPath);
+        // If we are here, this means both path are ok and there can't be an
+        // exception thrown
+        fs::rename(tmpFilePath, FLAGS_hubSeedsBackupPath);
     } catch (fs::filesystem_error& e) {
-      fs::remove(tmpFilePath);
       LOG(ERROR) << "Failed renaming old hub addresses backup file";
       return;
     }
-    fs::remove(pathToDelete);
-    // If we are here, this means both path are ok and there can't be an
-    // exception thrown
-    fs::rename(tmpFilePath, FLAGS_hubSeedsBackupPath);
+
   }
 }
 

--- a/hub/service/sweep_service.cc
+++ b/hub/service/sweep_service.cc
@@ -8,6 +8,9 @@
 #include "hub/service/sweep_service.h"
 
 #include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <numeric>
 #include <sstream>
 #include <string>
@@ -16,7 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -39,10 +41,70 @@ DEFINE_uint32(sweep_max_withdraw, 7,
 DEFINE_uint32(sweep_max_deposit, 5,
               "Maximum number of user deposits to process per sweep.");
 
+// Hub unswept addresses backup
+DEFINE_string(hubAdressesBackupPath, "",
+              "Path for file that will be used to backup unswep hub addresses");
+
 }  // namespace
 
 namespace hub {
 namespace service {
+
+void SweepService::backupUnsweptHubAddresses() const {
+  namespace fs = std::filesystem;
+  if (FLAGS_hubAdressesBackupPath.empty()) {
+    return;
+  }
+
+  std::string tmpFilePath = FLAGS_hubAdressesBackupPath;
+  bool replace = false;
+  auto& dbConnection = db::DBManager::get().connection();
+
+  if (fs::exists(FLAGS_hubAdressesBackupPath)) {
+    tmpFilePath += "_tmp";
+    replace = true;
+  }
+
+  std::ofstream outputFile;
+  // enable exceptions
+  outputFile.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
+  try {
+    outputFile.open(tmpFilePath);
+    auto allHubInputs =
+        dbConnection.getAllHubInputs(std::chrono::system_clock::now());
+
+    for (auto&& inp : allHubInputs) {
+      outputFile << inp.address.str() << ";" << inp.uuid.str() << ";"
+                 << inp.amount << "\n";
+    }
+  } catch (std::ifstream::failure e) {
+    outputFile.close();
+    if (fs::exists(tmpFilePath)) {
+      fs::remove(tmpFilePath);
+    }
+    LOG(ERROR) << "Failed backing up hub addresses";
+    return;
+  }
+
+  outputFile.close();
+
+  if (replace) {
+    std::string pathToDelete = FLAGS_hubAdressesBackupPath + "_to_delete";
+
+    try {
+      fs::rename(FLAGS_hubAdressesBackupPath, pathToDelete);
+    } catch (fs::filesystem_error& e) {
+      fs::remove(tmpFilePath);
+      LOG(ERROR) << "Failed renaming old hub addresses backup file";
+      return;
+    }
+    fs::remove(pathToDelete);
+    // If we are here, this means both path are ok and there can't be an
+    // exception thrown
+    fs::rename(tmpFilePath, FLAGS_hubAdressesBackupPath);
+  }
+}
 
 bool SweepService::doTick() {
   LOG(INFO) << "Starting sweep.";
@@ -140,6 +202,10 @@ bool SweepService::doTick() {
     // 6. Commit to DB
     hub::bundle_utils::persistToDatabase(bundle, deposits, hubInputs,
                                          withdrawals, {hubOutput});
+
+    if (remainder > 0) {
+      backupUnsweptHubAddresses();
+    }
 
     transaction->commit();
     LOG(INFO) << "Sweep complete.";

--- a/hub/service/sweep_service.cc
+++ b/hub/service/sweep_service.cc
@@ -94,9 +94,6 @@ void SweepService::backupUnsweptHubAddresses() const {
 
   if (replace) {
     try {
-        fs::remove(FLAGS_hubSeedsBackupPath);
-        // If we are here, this means both path are ok and there can't be an
-        // exception thrown
         fs::rename(tmpFilePath, FLAGS_hubSeedsBackupPath);
     } catch (fs::filesystem_error& e) {
       LOG(ERROR) << "Failed renaming old hub addresses backup file";

--- a/hub/service/sweep_service.h
+++ b/hub/service/sweep_service.h
@@ -56,6 +56,9 @@ class SweepService : public ScheduledService {
   bool doTick() override;
   /// an cppclient::IotaAPI compliant API provider
   const std::shared_ptr<cppclient::IotaAPI> _api;
+
+ private:
+  void backupUnsweptHubAddresses() const;
 };
 
 }  // namespace service


### PR DESCRIPTION
Backup unswept hub addresses info, every line is formatted as  "address;seed;amount"
backup is done only when `hubAdressesBackupPath` conf is provided

- Enhancement (a non-breaking change which adds functionality)


- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
