### PR TITLE
bazel: sync Tanglescope version to 331f0ed

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,7 +96,7 @@ git_repository(
 
 git_repository(
     name = "TangleScope",
-    commit = "d928607115bf554fbbe9009fdc696116a703d8b1",
+    commit = "331f0ed48a383c940db76cfb44f8dd07f5eca5b1",
     remote = "https://github.com/iotaledger/TangleScope.git",
 )
 


### PR DESCRIPTION
# Description

https://github.com/iotaledger/TangleScope has been updated to handle rogue node who don't properly close SSL streams.
This PR just updates the bazel dependency to the current HEAD of TangleScope


## Type of change

- Bug fix : allow hub to connect with node not properly closing SSL streams

# How Has This Been Tested?

build + connection with `nodes.thetangle.org` (only works once the PR is applied)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
