### PR TITLE
SignBundle: fail command if bundleHash is absent, not present

### DIFF
--- a/hub/commands/sign_bundle.cc
+++ b/hub/commands/sign_bundle.cc
@@ -55,7 +55,7 @@ boost::property_tree::ptree SignBundle::doProcess(
   }
 
   auto maybeBundleHash = request.get_optional<std::string>("bundleHash");
-  if (maybeBundleHash) {
+  if (!maybeBundleHash) {
     tree.add("error",
              common::cmd::getErrorString(common::cmd::MISSING_ARGUMENT));
     return tree;


### PR DESCRIPTION

# Description

Currently, `SignBundle` RPC call fails is `bundleHash` is provided as an argument (while it should be the opposite), so `SignBundle` is unusable.


## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Before patch: can't call `SignBundle`
After patch: can call `SignBundle`


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
